### PR TITLE
MCPJVM-18: Add probe_class_info to verify loaded JVM bytecode/version at runtime

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,6 +126,17 @@ Optional:
 
 `probe_wait_hit` now returns a structured `service_unreachable`/`probe_unreachable` outcome when the probe endpoint is unreachable, distinct from `timeout_no_inline_hit` when the endpoint is reachable but no inline hit is observed.
 
+### Probe Outcome Semantics
+
+Use these outcomes to avoid mixing stale runtime mismatch with execution misses:
+
+- `invalid_line_target`: Requested line key is not resolvable in current runtime bytecode.  
+  Next action: rebuild app artifact and restart JVM, then rerun probe.
+- `timeout_no_inline_hit`: Probe endpoint reachable and line key resolvable, but no inline hit observed in the polling window.  
+  Next action: verify trigger path/branching and rerun `probe_wait_hit`.
+- `probe_unreachable`: Probe endpoint not reachable from MCP.  
+  Next action: verify `MCP_PROBE_BASE_URL`, agent process reachability, and network/path wiring.
+
 ---
 
 ## MCP Tools

--- a/src/tools/probe.ts
+++ b/src/tools/probe.ts
@@ -24,6 +24,22 @@ const DEFAULT_PROBE_WAIT_UNREACHABLE_MAX_RETRIES =
   CONFIG_DEFAULTS.PROBE_WAIT_UNREACHABLE_MAX_RETRIES;
 const HARD_MAX_PROBE_WAIT_UNREACHABLE_MAX_RETRIES =
   CONFIG_DEFAULTS.PROBE_WAIT_UNREACHABLE_MAX_RETRIES_MAX;
+type ProbeGuidance = { actionCode: string; nextAction: string };
+
+const GUIDANCE_RUNTIME_NOT_ALIGNED: ProbeGuidance = {
+  actionCode: "runtime_not_aligned",
+  nextAction: "rebuild_app_artifact_and_restart_jvm_then_rerun_probe",
+};
+
+const GUIDANCE_LINE_NOT_EXECUTED_IN_WINDOW: ProbeGuidance = {
+  actionCode: "line_not_executed_in_window",
+  nextAction: "verify_trigger_path_or_branch_then_rerun_probe_wait_hit",
+};
+
+const GUIDANCE_PROBE_CONNECTIVITY_ISSUE: ProbeGuidance = {
+  actionCode: "probe_connectivity_issue",
+  nextAction: "verify_probe_base_url_and_agent_reachability_then_rerun",
+};
 
 function buildTextResponse(
   structuredContent: Record<string, unknown>,
@@ -203,6 +219,8 @@ function buildServiceUnreachableResponse(args: {
       hit: false,
       inline: false,
       reason: "service_unreachable",
+      actionCode: GUIDANCE_PROBE_CONNECTIVITY_ISSUE.actionCode,
+      nextAction: GUIDANCE_PROBE_CONNECTIVITY_ISSUE.nextAction,
       endpoint: args.details.endpoint,
       lastError: args.details.lastError,
       unreachableAttempts: args.details.unreachableAttempts,
@@ -240,6 +258,8 @@ function buildServiceUnreachableResponse(args: {
       `${args.details.unreachableMaxRetries}`,
     httpCode: 503,
     httpResponse: structuredContent.result,
+    actionCode: GUIDANCE_PROBE_CONNECTIVITY_ISSUE.actionCode,
+    nextAction: GUIDANCE_PROBE_CONNECTIVITY_ISSUE.nextAction,
     runDuration: `${Date.now() - args.waitStartEpochMs}ms`,
     runNotes: `probe_wait_hit service unreachable during ${args.stage}`,
   });
@@ -374,6 +394,14 @@ async function probeStatusSingle(args: {
     : json !== null
       ? `hitCount=${typeof json.hitCount === "number" ? json.hitCount : 0}, lastHitEpochMs=${typeof json.lastHitEpochMs === "number" ? json.lastHitEpochMs : 0}`
       : "No JSON probe payload";
+  const guidance = lineValidation.invalidLineTarget ? GUIDANCE_RUNTIME_NOT_ALIGNED : undefined;
+  if (guidance) {
+    structuredContent.result = {
+      reason: "invalid_line_target",
+      actionCode: guidance.actionCode,
+      nextAction: guidance.nextAction,
+    };
+  }
 
   const text = formatProbeOutput({
     probeKey: resolvedKey,
@@ -384,6 +412,7 @@ async function probeStatusSingle(args: {
     apiOutcome: res.status >= 200 && res.status < 300 ? "ok" : "error",
     reproStatus,
     probeHit,
+    ...(guidance ? { actionCode: guidance.actionCode, nextAction: guidance.nextAction } : {}),
     httpCode: res.status,
     httpResponse: res.json ?? res.text,
     runtimeMode: typeof json?.mode === "string" ? json.mode : undefined,
@@ -467,6 +496,7 @@ async function probeStatusBatch(args: {
     }
     const hitCount = typeof row.hitCount === "number" ? row.hitCount : 0;
     const lineValidation = readLineValidation(row);
+    const guidance = lineValidation.invalidLineTarget ? GUIDANCE_RUNTIME_NOT_ALIGNED : undefined;
     localByKey.set(key, {
       key,
       executionHit: lineValidation.invalidLineTarget
@@ -484,6 +514,9 @@ async function probeStatusBatch(args: {
       probeHit: lineValidation.invalidLineTarget
         ? invalidLineTargetProbeHitMessage(hitCount)
         : `hitCount=${hitCount}, lastHitEpochMs=${typeof row.lastHitEpochMs === "number" ? row.lastHitEpochMs : 0}`,
+      ...(guidance
+        ? { actionCode: guidance.actionCode, nextAction: guidance.nextAction }
+        : {}),
       httpCode: remoteResponse?.status ?? 200,
       httpResponse: row,
       runtimeMode: typeof row.mode === "string" ? row.mode : undefined,
@@ -612,6 +645,12 @@ async function probeResetSingle(args: {
     probeHit: lineValidation.invalidLineTarget
       ? `${invalidLineTargetProbeHitMessage(0)}; counter reset requested`
       : "counter reset requested",
+    ...(lineValidation.invalidLineTarget
+      ? {
+          actionCode: GUIDANCE_RUNTIME_NOT_ALIGNED.actionCode,
+          nextAction: GUIDANCE_RUNTIME_NOT_ALIGNED.nextAction,
+        }
+      : {}),
     httpCode: res.status,
     httpResponse: res.json ?? res.text,
     runDuration: "Not measured",
@@ -712,6 +751,12 @@ async function probeResetBatch(args: {
       probeHit: lineValidation.invalidLineTarget
         ? `${invalidLineTargetProbeHitMessage(0)}; counter reset requested`
         : "counter reset requested",
+      ...(lineValidation.invalidLineTarget
+        ? {
+            actionCode: GUIDANCE_RUNTIME_NOT_ALIGNED.actionCode,
+            nextAction: GUIDANCE_RUNTIME_NOT_ALIGNED.nextAction,
+          }
+        : {}),
       httpCode: res.status,
       httpResponse: row,
     });
@@ -914,6 +959,8 @@ export async function probeWaitHit(args: {
           hit: false,
           inline: false,
           reason: "invalid_line_target",
+          actionCode: GUIDANCE_RUNTIME_NOT_ALIGNED.actionCode,
+          nextAction: GUIDANCE_RUNTIME_NOT_ALIGNED.nextAction,
           lineValidation: baselineLineValidation.lineValidation ?? "invalid_line_target",
           lastStatus: baselineJson,
         },
@@ -928,6 +975,8 @@ export async function probeWaitHit(args: {
         apiOutcome: "error",
         reproStatus: "invalid_line_target",
         probeHit: invalidLineTargetProbeHitMessage(baselineHitCount),
+        actionCode: GUIDANCE_RUNTIME_NOT_ALIGNED.actionCode,
+        nextAction: GUIDANCE_RUNTIME_NOT_ALIGNED.nextAction,
         httpCode: 422,
         httpResponse: structuredContent.result,
         runtimeMode: typeof baselineJson?.mode === "string" ? baselineJson.mode : undefined,
@@ -1037,6 +1086,8 @@ export async function probeWaitHit(args: {
             hit: false,
             inline: false,
             reason: "invalid_line_target",
+            actionCode: GUIDANCE_RUNTIME_NOT_ALIGNED.actionCode,
+            nextAction: GUIDANCE_RUNTIME_NOT_ALIGNED.nextAction,
             lineValidation: lineValidation.lineValidation ?? "invalid_line_target",
             lastStatus: json ?? null,
           },
@@ -1051,6 +1102,8 @@ export async function probeWaitHit(args: {
           apiOutcome: "error",
           reproStatus: "invalid_line_target",
           probeHit: invalidLineTargetProbeHitMessage(baselineHitCount),
+          actionCode: GUIDANCE_RUNTIME_NOT_ALIGNED.actionCode,
+          nextAction: GUIDANCE_RUNTIME_NOT_ALIGNED.nextAction,
           httpCode: 422,
           httpResponse: structuredContent.result,
           runtimeMode: typeof json?.mode === "string" ? json.mode : undefined,
@@ -1123,7 +1176,15 @@ export async function probeWaitHit(args: {
       unreachableRetryEnabled,
       unreachableMaxRetries,
     },
-    result: { hit: false, inline: false, reason: "timeout_no_inline_hit", last, staleCandidate },
+    result: {
+      hit: false,
+      inline: false,
+      reason: "timeout_no_inline_hit",
+      actionCode: GUIDANCE_LINE_NOT_EXECUTED_IN_WINDOW.actionCode,
+      nextAction: GUIDANCE_LINE_NOT_EXECUTED_IN_WINDOW.nextAction,
+      last,
+      staleCandidate,
+    },
   };
   const text = formatProbeOutput({
     probeKey: resolvedKey,
@@ -1135,6 +1196,8 @@ export async function probeWaitHit(args: {
     apiOutcome: "timeout",
     reproStatus: classifyReproStatusStrictLine(resolvedKey, false),
     probeHit: "no inline line hit observed",
+    actionCode: GUIDANCE_LINE_NOT_EXECUTED_IN_WINDOW.actionCode,
+    nextAction: GUIDANCE_LINE_NOT_EXECUTED_IN_WINDOW.nextAction,
     httpCode: 408,
     httpResponse: structuredContent.result,
     runtimeMode:

--- a/src/tools/probe/output.util.ts
+++ b/src/tools/probe/output.util.ts
@@ -44,6 +44,8 @@ export function formatProbeOutput(args: {
   syntheticWarning?: string | undefined;
   runDuration: string;
   runNotes?: string;
+  actionCode?: string;
+  nextAction?: string;
 }): string {
   const parsedRequest = parseHttpRequestLine(args.httpRequest);
   const requestMethod = args.requestMethod ?? parsedRequest.method;
@@ -70,6 +72,8 @@ export function formatProbeOutput(args: {
       apiOutcome: args.apiOutcome,
       reproStatus: args.reproStatus,
       probeHit: args.probeHit,
+      actionCode: args.actionCode ?? null,
+      nextAction: args.nextAction ?? null,
       runtime: {
         mode: runtimeMode,
         synthetic: runtimeMode === "actuate",

--- a/src/tools/recipe_generate/run_notes.util.ts
+++ b/src/tools/recipe_generate/run_notes.util.ts
@@ -21,6 +21,9 @@ export function buildRunNotes(args: {
     notes.push("Probe tools are disabled for this route.");
   } else {
     notes.push("Probe verification requires strict line key Class#method:line.");
+    notes.push(
+      "Interpretation guide: invalid_line_target implies runtime/source mismatch (rebuild + restart JVM); timeout_no_inline_hit implies no observed execution in-window.",
+    );
   }
   if (
     typeof args.lineHint === "number" &&

--- a/src/utils/recipe_execution_plan.util.ts
+++ b/src/utils/recipe_execution_plan.util.ts
@@ -222,7 +222,8 @@ function buildSingleLineProbeSteps(args: {
     title: "Verify single-line probe hit",
     instruction:
       `Require line_hit on ${args.lineTarget} using probe_wait_hit.` +
-      (args.targetFile ? ` Correlate with ${args.targetFile}:${args.lineHint}.` : ""),
+      (args.targetFile ? ` Correlate with ${args.targetFile}:${args.lineHint}.` : "") +
+      " If probe_wait_hit returns invalid_line_target, rebuild the app artifact and restart the JVM before rerun.",
   });
   if (args.actuationEnabled && args.actuationConfigured) {
     steps.push(
@@ -296,7 +297,8 @@ function buildCombinedSteps(args: {
     title: "Verify API and line probe outcomes",
     instruction:
       `Require line_hit on ${args.lineTarget} via probe_wait_hit and validate API regression assertions in the same run.` +
-      (args.targetFile ? ` Correlate with ${args.targetFile}:${args.lineHint}.` : ""),
+      (args.targetFile ? ` Correlate with ${args.targetFile}:${args.lineHint}.` : "") +
+      " If probe_wait_hit returns invalid_line_target, rebuild the app artifact and restart the JVM before rerun.",
   });
   if (args.actuationEnabled && args.actuationConfigured) {
     steps.push(

--- a/test/tools/probe.test.ts
+++ b/test/tools/probe.test.ts
@@ -54,7 +54,10 @@ test("probe_status returns invalid_line_target for unresolved runtime line", asy
     assert.equal(parsed.reproStatus, "invalid_line_target");
     assert.equal(parsed.executionHit, "not_hit");
     assert.match(parsed.probeHit, /cannot be resolved to executable bytecode/i);
+    assert.equal(parsed.actionCode, "runtime_not_aligned");
+    assert.equal(parsed.nextAction, "rebuild_app_artifact_and_restart_jvm_then_rerun_probe");
     assert.equal(out.structuredContent.response.json.lineValidation, "invalid_line_target");
+    assert.equal(out.structuredContent.result.actionCode, "runtime_not_aligned");
   });
   assert.equal(calls, 1);
 });
@@ -104,7 +107,10 @@ test("probe_wait_hit exits immediately for invalid_line_target", async () => {
     const parsed = parseProbeText(out);
     assert.equal(parsed.reproStatus, "invalid_line_target");
     assert.equal(parsed.httpCode, 422);
+    assert.equal(parsed.actionCode, "runtime_not_aligned");
+    assert.equal(parsed.nextAction, "rebuild_app_artifact_and_restart_jvm_then_rerun_probe");
     assert.equal(out.structuredContent.result.reason, "invalid_line_target");
+    assert.equal(out.structuredContent.result.actionCode, "runtime_not_aligned");
   });
   assert.equal(calls, 1);
 });
@@ -126,6 +132,8 @@ test("probe_wait_hit returns structured service_unreachable by default", async (
     const parsed = parseProbeText(out);
     assert.equal(parsed.reproStatus, "probe_unreachable");
     assert.equal(parsed.httpCode, 503);
+    assert.equal(parsed.actionCode, "probe_connectivity_issue");
+    assert.equal(parsed.nextAction, "verify_probe_base_url_and_agent_reachability_then_rerun");
     assert.equal(out.structuredContent.result.reason, "service_unreachable");
     assert.equal(out.structuredContent.result.unreachableAttempts, 1);
     assert.equal(out.structuredContent.result.unreachableRetryEnabled, false);
@@ -182,11 +190,44 @@ test("probe_wait_hit returns structured service_unreachable after unreachable re
     const parsed = parseProbeText(out);
     assert.equal(parsed.reproStatus, "probe_unreachable");
     assert.equal(parsed.httpCode, 503);
+    assert.equal(parsed.actionCode, "probe_connectivity_issue");
+    assert.equal(parsed.nextAction, "verify_probe_base_url_and_agent_reachability_then_rerun");
     assert.equal(out.structuredContent.result.reason, "service_unreachable");
     assert.equal(out.structuredContent.result.unreachableAttempts, 2);
     assert.equal(out.structuredContent.result.unreachableRetryEnabled, true);
   });
   assert.equal(calls, 2);
+});
+
+test("probe_wait_hit timeout_no_inline_hit returns line-not-executed guidance", async () => {
+  let calls = 0;
+  await withMockedFetch(async () => {
+    calls += 1;
+    return jsonResponse(200, {
+      key: "com.example.Catalog#updateAndStageSynonymRule:122",
+      hitCount: 0,
+      lastHitEpochMs: 0,
+      mode: "observe",
+      lineResolvable: true,
+      lineValidation: "resolvable",
+    });
+  }, async () => {
+    const out = await probeWaitHit({
+      key: "com.example.Catalog#updateAndStageSynonymRule:122",
+      baseUrl: "http://127.0.0.1:9191",
+      statusPath: "/__probe/status",
+      timeoutMs: 120,
+      pollIntervalMs: 60,
+      maxRetries: 1,
+    });
+    const parsed = parseProbeText(out);
+    assert.equal(parsed.httpCode, 408);
+    assert.equal(parsed.actionCode, "line_not_executed_in_window");
+    assert.equal(parsed.nextAction, "verify_trigger_path_or_branch_then_rerun_probe_wait_hit");
+    assert.equal(out.structuredContent.result.reason, "timeout_no_inline_hit");
+    assert.equal(out.structuredContent.result.actionCode, "line_not_executed_in_window");
+  });
+  assert.ok(calls >= 2);
 });
 
 test("probe_status remains backward-compatible when line validation fields are absent", async () => {

--- a/test/utils/recipe-execution-plan.test.ts
+++ b/test/utils/recipe-execution-plan.test.ts
@@ -71,6 +71,8 @@ test("single_line_probe enforces reset -> execute -> verify order", () => {
   assert.match(plan.steps[1].instruction, /^GET /);
   assert.match(plan.steps[2].instruction, /probe_wait_hit/);
   assert.doesNotMatch(plan.steps[2].instruction, /probe_status/);
+  assert.match(plan.steps[2].instruction, /invalid_line_target/i);
+  assert.match(plan.steps[2].instruction, /rebuild the app artifact and restart the JVM/i);
   assert.deepEqual(plan.probeCallPlan, {
     total: 2,
     verificationMethod: "probe_wait_hit",
@@ -107,6 +109,8 @@ test("combined mode enforces reset -> API -> verify order", () => {
   assert.match(plan.steps[2].instruction, /probe_wait_hit/);
   assert.doesNotMatch(plan.steps[2].instruction, /probe_status/);
   assert.match(plan.steps[2].instruction, /API regression assertions/);
+  assert.match(plan.steps[2].instruction, /invalid_line_target/i);
+  assert.match(plan.steps[2].instruction, /rebuild the app artifact and restart the JVM/i);
   assert.deepEqual(plan.probeCallPlan, {
     total: 2,
     verificationMethod: "probe_wait_hit",


### PR DESCRIPTION
What changed

- Added deterministic guidance fields (actionCode, nextAction) to probe output payloads via output.util.ts.
- Wired status-specific guidance in probe.ts:

1. invalid_line_target -> runtime_not_aligned + rebuild/restart JVM guidance.
2. timeout_no_inline_hit -> line_not_executed_in_window + trigger/branch rerun guidance.
3. probe_unreachable -> probe_connectivity_issue + wiring/base URL guidance.

- Updated recipe execution instructions to explicitly handle stale runtime mismatch in recipe_execution_plan.util.ts.
- Added interpretation note in recipe run notes in run_notes.util.ts.
- Documented troubleshooting semantics in README.md.
- Extended UT coverage in:

1. probe.test.ts
2. recipe-execution-plan.test.ts