### PR TITLE
MCPJVM-24: probe_reset reports invalid line targets as success-like outcomes

### DIFF
--- a/src/tools/probe.ts
+++ b/src/tools/probe.ts
@@ -623,9 +623,17 @@ async function probeResetSingle(args: {
   const json = res.json as Record<string, unknown> | null;
   const lineValidation = readLineValidation(json);
   const isOk = res.status >= 200 && res.status < 300;
+  const semanticOk = isOk && !lineValidation.invalidLineTarget;
 
-  if (isOk) {
+  if (semanticOk) {
     LAST_RESET_EPOCH_BY_KEY.set(resolvedKey, Date.now());
+  }
+  if (lineValidation.invalidLineTarget) {
+    structuredContent.result = {
+      reason: "invalid_line_target",
+      actionCode: GUIDANCE_RUNTIME_NOT_ALIGNED.actionCode,
+      nextAction: GUIDANCE_RUNTIME_NOT_ALIGNED.nextAction,
+    };
   }
 
   const text = formatProbeOutput({
@@ -636,7 +644,7 @@ async function probeResetSingle(args: {
     requestHeaders: { "content-type": "application/json" },
     requestBody: { key: resolvedKey },
     executionHit: "not_applicable",
-    apiOutcome: isOk ? "ok" : "error",
+    apiOutcome: semanticOk ? "ok" : "error",
     reproStatus: lineValidation.invalidLineTarget
       ? "invalid_line_target"
       : isOk
@@ -736,13 +744,14 @@ async function probeResetBatch(args: {
     const lineValidation = readLineValidation(row);
     const rowOk =
       typeof row.ok === "boolean" ? row.ok : res.status >= 200 && res.status < 300;
-    if (rowOk) {
+    const rowSemanticOk = rowOk && !lineValidation.invalidLineTarget;
+    if (rowSemanticOk) {
       LAST_RESET_EPOCH_BY_KEY.set(key, Date.now());
     }
     remoteResults.push({
       key,
       executionHit: "not_applicable",
-      apiOutcome: rowOk ? "ok" : "error",
+      apiOutcome: rowSemanticOk ? "ok" : "error",
       reproStatus: lineValidation.invalidLineTarget
         ? "invalid_line_target"
         : rowOk

--- a/test/tools/probe.test.ts
+++ b/test/tools/probe.test.ts
@@ -78,8 +78,10 @@ test("probe_reset returns invalid_line_target semantics when runtime line is unr
     });
     const parsed = parseProbeText(out);
     assert.equal(parsed.reproStatus, "invalid_line_target");
-    assert.equal(parsed.apiOutcome, "ok");
+    assert.equal(parsed.apiOutcome, "error");
     assert.match(parsed.probeHit, /counter reset requested/i);
+    assert.equal(out.structuredContent.result.reason, "invalid_line_target");
+    assert.equal(out.structuredContent.result.actionCode, "runtime_not_aligned");
   });
 });
 
@@ -296,7 +298,8 @@ test("probe_status supports keys[] batch with partial success semantics", async 
 test("probe_reset supports keys[] batch with partial success semantics", async () => {
   let calls = 0;
   let postedBody: any = null;
-  const lineKey = "com.example.Catalog#updateAndStageSynonymRule:122";
+  const validLineKey = "com.example.Catalog#updateAndStageSynonymRule:122";
+  const invalidLineKey = "com.example.Catalog#updateAndStageSynonymRule:123";
   const nonLineKey = "com.example.Catalog#updateAndStageSynonymRule";
 
   await withMockedFetch(async (_input, init) => {
@@ -305,19 +308,25 @@ test("probe_reset supports keys[] batch with partial success semantics", async (
     return jsonResponse(200, {
       ok: true,
       selector: "keys",
-      count: 1,
+      count: 2,
       results: [
         {
           ok: true,
-          key: lineKey,
+          key: validLineKey,
           lineResolvable: true,
           lineValidation: "resolvable",
+        },
+        {
+          ok: true,
+          key: invalidLineKey,
+          lineResolvable: false,
+          lineValidation: "invalid_line_target",
         },
       ],
     });
   }, async () => {
     const out = await probeReset({
-      keys: [lineKey, nonLineKey, lineKey],
+      keys: [validLineKey, invalidLineKey, nonLineKey, validLineKey],
       baseUrl: "http://127.0.0.1:9191",
       resetPath: "/__probe/reset",
     });
@@ -325,13 +334,18 @@ test("probe_reset supports keys[] batch with partial success semantics", async (
     const summary = parsed.summary as Record<string, unknown>;
     assert.equal(parsed.mode, "probe_batch");
     assert.equal(parsed.operation, "reset");
-    assert.equal(summary.total, 2);
+    assert.equal(summary.total, 3);
     assert.equal(summary.ok, 1);
-    assert.equal(summary.failed, 1);
+    assert.equal(summary.failed, 2);
+    const results = parsed.results as Array<Record<string, unknown>>;
+    const invalidRow = results.find((row) => row.key === invalidLineKey);
+    if (!invalidRow) throw new Error("expected invalid line row in batch response");
+    assert.equal(invalidRow.apiOutcome, "error");
+    assert.equal(invalidRow.reproStatus, "invalid_line_target");
   });
 
   assert.equal(calls, 1);
-  assert.deepEqual(postedBody, { keys: [lineKey] });
+  assert.deepEqual(postedBody, { keys: [validLineKey, invalidLineKey] });
 });
 
 test("probe_reset supports className selector and class_not_found no-op response", async () => {


### PR DESCRIPTION
**MR Description**  
This MR tightens `probe_reset` semantics without changing transport behavior.

### What changed
- Fixed accidental corruption in `probe.ts` (removed literal `` `r`n `` artifacts).
- Updated `probeResetSingle`:
  - Added semantic success check: `transport_ok && !invalid_line_target`.
  - `apiOutcome` now becomes `"error"` for `invalid_line_target`.
  - Added explicit structured result for invalid line target (`reason/actionCode/nextAction`).
  - `LAST_RESET_EPOCH_BY_KEY` is updated only on semantic success.
- Updated `probeResetBatch`:
  - Row-level `apiOutcome` now treats `invalid_line_target` as semantic failure.
  - Row-level baseline timestamp updates only on semantic success.
  - Batch summary now correctly counts invalid-line rows as failed.

### Scope
- Intentionally limited to `probe_reset` behavior.
- No new tools/endpoints.
- No behavioral changes to `probe_status` or `probe_wait_hit`.

### Tests
Updated `test/tools/probe.test.ts`:
- Single reset invalid-line case now expects:
  - `apiOutcome: "error"`
  - `structuredContent.result.reason: "invalid_line_target"`
- Batch reset test now includes an invalid line key and verifies:
  - invalid row has semantic failure
  - summary reflects failed count correctly
  - posted keys include both valid and invalid line keys

Validation:
- `node --test -r ts-node/register test/tools/probe.test.ts`
- Result: 13 passed, 0 failed