### PR TITLE
MCPJVM-21: java-agent: Add configurable per-method capture buffer and remove method-enter hit counting

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,12 @@ mvn -f java-agent\pom.xml -DskipTests package
 -javaagent:C:\Users\Altheo\repository\mcp-jvm-debugger\java-agent\target\mcp-jvm-probe-agent-0.1.0-all.jar=host=0.0.0.0;port=9191;include=com.nimbly.phshoesbackend.**;exclude=com.nimbly.mcpjvmdebugger.agent.**,**.config.**,**Test
 ```
 
+Optional Java agent capture history tuning:
+
+- Agent arg: `captureMethodBufferSize=<1..32>` (default `3`)
+- JVM property: `-Dmcp.probe.capture.method.buffer.size=<1..32>`
+- Environment variable: `MCP_PROBE_CAPTURE_METHOD_BUFFER_SIZE=<1..32>`
+
 ---
 
 ## Install MCP

--- a/java-agent/README.md
+++ b/java-agent/README.md
@@ -19,7 +19,7 @@ java-agent\target\mcp-jvm-probe-agent-0.1.0-all.jar
 Use JVM args (example):
 
 ```text
--javaagent:C:\Users\Altheo\repository\mcp-jvm-debugger\java-agent\target\mcp-jvm-probe-agent-0.1.0-all.jar=host=127.0.0.1;port=9191;mode=observe;actuatorId=none;include=com.nimbly.**;exclude=com.nimbly.mcpjvmdebugger.agent.**,**.config.**,**Test
+-javaagent:C:\Users\Altheo\repository\mcp-jvm-debugger\java-agent\target\mcp-jvm-probe-agent-0.1.0-all.jar=host=127.0.0.1;port=9191;mode=observe;actuatorId=none;captureMethodBufferSize=3;include=com.nimbly.**;exclude=com.nimbly.mcpjvmdebugger.agent.**,**.config.**,**Test
 ```
 
 `include` and `exclude` are comma-separated glob patterns over dotted class names.
@@ -50,9 +50,14 @@ Use JVM args (example):
   - `-Dmcp.probe.capture.enabled=true|false` or env `MCP_PROBE_CAPTURE_ENABLED`
   - `-Dmcp.probe.capture.max.keys=<int>` or env `MCP_PROBE_CAPTURE_MAX_KEYS`
   - `-Dmcp.probe.capture.max.args=<int>` or env `MCP_PROBE_CAPTURE_MAX_ARGS`
+  - `-Dmcp.probe.capture.method.buffer.size=<int>` or env `MCP_PROBE_CAPTURE_METHOD_BUFFER_SIZE`
   - `-Dmcp.probe.capture.preview.max.chars=<int>` or env `MCP_PROBE_CAPTURE_PREVIEW_MAX_CHARS`
   - `-Dmcp.probe.capture.stored.max.chars=<int>` or env `MCP_PROBE_CAPTURE_STORED_MAX_CHARS`
   - `-Dmcp.probe.capture.redaction=basic|off` or env `MCP_PROBE_CAPTURE_REDACTION`
+- `captureMethodBufferSize` controls recent captures retained per `Class#method`.
+  - Range: `1..32`
+  - Default: `3`
+  - Precedence: `agent arg > JVM system property > environment variable > default`
 
 ### Endpoints Exposed By Agent
 

--- a/java-agent/src/main/java/com/nimbly/mcpjvmdebugger/agent/AgentConfig.java
+++ b/java-agent/src/main/java/com/nimbly/mcpjvmdebugger/agent/AgentConfig.java
@@ -20,6 +20,7 @@ final class AgentConfig {
   final boolean captureEnabled;
   final int captureMaxKeys;
   final int captureMaxArgs;
+  final int captureMethodBufferSize;
   final int capturePreviewMaxChars;
   final int captureStoredMaxChars;
   final String captureRedactionMode;
@@ -38,6 +39,7 @@ final class AgentConfig {
       boolean captureEnabled,
       int captureMaxKeys,
       int captureMaxArgs,
+      int captureMethodBufferSize,
       int capturePreviewMaxChars,
       int captureStoredMaxChars,
       String captureRedactionMode,
@@ -53,6 +55,7 @@ final class AgentConfig {
     this.captureEnabled = captureEnabled;
     this.captureMaxKeys = captureMaxKeys;
     this.captureMaxArgs = captureMaxArgs;
+    this.captureMethodBufferSize = captureMethodBufferSize;
     this.capturePreviewMaxChars = capturePreviewMaxChars;
     this.captureStoredMaxChars = captureStoredMaxChars;
     this.captureRedactionMode = captureRedactionMode;
@@ -74,6 +77,7 @@ final class AgentConfig {
     boolean captureEnabled = readDefaultCaptureEnabled();
     int captureMaxKeys = readDefaultCaptureMaxKeys();
     int captureMaxArgs = readDefaultCaptureMaxArgs();
+    int captureMethodBufferSize = readDefaultCaptureMethodBufferSize();
     int capturePreviewMaxChars = readDefaultCapturePreviewMaxChars();
     int captureStoredMaxChars = readDefaultCaptureStoredMaxChars();
     String captureRedactionMode = readDefaultCaptureRedactionMode();
@@ -118,6 +122,11 @@ final class AgentConfig {
           captureMaxKeys = parseInt(v, 1000, 10, 20_000);
         } else if ("captureMaxArgs".equalsIgnoreCase(k)) {
           captureMaxArgs = parseInt(v, 32, 1, 512);
+        } else if (
+            "captureMethodBufferSize".equalsIgnoreCase(k)
+                || "captureBufferSize".equalsIgnoreCase(k)
+        ) {
+          captureMethodBufferSize = parseInt(v, 3, 1, 32);
         } else if ("capturePreviewMaxChars".equalsIgnoreCase(k)) {
           capturePreviewMaxChars = parseInt(v, 1024, 64, 65_536);
         } else if ("captureStoredMaxChars".equalsIgnoreCase(k)) {
@@ -149,6 +158,7 @@ final class AgentConfig {
     actuateTargetKey = normalizeTargetKey(actuateTargetKey);
     captureMaxKeys = parseInt(String.valueOf(captureMaxKeys), 1000, 10, 20_000);
     captureMaxArgs = parseInt(String.valueOf(captureMaxArgs), 32, 1, 512);
+    captureMethodBufferSize = parseInt(String.valueOf(captureMethodBufferSize), 3, 1, 32);
     capturePreviewMaxChars = parseInt(String.valueOf(capturePreviewMaxChars), 1024, 64, 65_536);
     captureStoredMaxChars = parseInt(String.valueOf(captureStoredMaxChars), 16_384, 256, 524_288);
     captureRedactionMode = normalizeCaptureRedactionMode(captureRedactionMode);
@@ -169,6 +179,7 @@ final class AgentConfig {
         captureEnabled,
         captureMaxKeys,
         captureMaxArgs,
+        captureMethodBufferSize,
         capturePreviewMaxChars,
         captureStoredMaxChars,
         captureRedactionMode,
@@ -247,6 +258,16 @@ final class AgentConfig {
     if (fromEnv != null && !fromEnv.trim().isEmpty()) return parseInt(fromEnv, 32, 1, 512);
 
     return 32;
+  }
+
+  private static int readDefaultCaptureMethodBufferSize() {
+    String fromProp = System.getProperty("mcp.probe.capture.method.buffer.size");
+    if (fromProp != null && !fromProp.trim().isEmpty()) return parseInt(fromProp, 3, 1, 32);
+
+    String fromEnv = System.getenv("MCP_PROBE_CAPTURE_METHOD_BUFFER_SIZE");
+    if (fromEnv != null && !fromEnv.trim().isEmpty()) return parseInt(fromEnv, 3, 1, 32);
+
+    return 3;
   }
 
   private static int readDefaultCapturePreviewMaxChars() {

--- a/java-agent/src/main/java/com/nimbly/mcpjvmdebugger/agent/HitAdvice.java
+++ b/java-agent/src/main/java/com/nimbly/mcpjvmdebugger/agent/HitAdvice.java
@@ -6,14 +6,6 @@ import net.bytebuddy.implementation.bytecode.assign.Assigner;
 public final class HitAdvice {
   private HitAdvice() {}
 
-  @Advice.OnMethodEnter(suppress = Throwable.class)
-  public static void onEnter(
-      @Advice.Origin("#t") String dottedClassName,
-      @Advice.Origin("#m") String methodName
-  ) {
-    ProbeRuntime.hitByClassMethod(dottedClassName, methodName);
-  }
-
   @Advice.OnMethodExit(onThrowable = Throwable.class, suppress = Throwable.class)
   public static void onExit(
       @Advice.Origin("#t") String dottedClassName,

--- a/java-agent/src/main/java/com/nimbly/mcpjvmdebugger/agent/ProbeAgent.java
+++ b/java-agent/src/main/java/com/nimbly/mcpjvmdebugger/agent/ProbeAgent.java
@@ -23,6 +23,7 @@ public final class ProbeAgent {
         cfg.captureEnabled,
         cfg.captureMaxKeys,
         cfg.captureMaxArgs,
+        cfg.captureMethodBufferSize,
         cfg.capturePreviewMaxChars,
         cfg.captureStoredMaxChars,
         cfg.captureRedactionMode
@@ -42,6 +43,7 @@ public final class ProbeAgent {
       System.err.println("[probe-agent] captureEnabled: " + cfg.captureEnabled);
       System.err.println("[probe-agent] captureMaxKeys: " + cfg.captureMaxKeys);
       System.err.println("[probe-agent] captureMaxArgs: " + cfg.captureMaxArgs);
+      System.err.println("[probe-agent] captureMethodBufferSize: " + cfg.captureMethodBufferSize);
       System.err.println("[probe-agent] capturePreviewMaxChars: " + cfg.capturePreviewMaxChars);
       System.err.println("[probe-agent] captureStoredMaxChars: " + cfg.captureStoredMaxChars);
       System.err.println("[probe-agent] captureRedactionMode: " + cfg.captureRedactionMode);

--- a/java-agent/src/main/java/com/nimbly/mcpjvmdebugger/agent/ProbeRuntime.java
+++ b/java-agent/src/main/java/com/nimbly/mcpjvmdebugger/agent/ProbeRuntime.java
@@ -3,10 +3,12 @@ package com.nimbly.mcpjvmdebugger.agent;
 import java.lang.reflect.Array;
 import java.lang.reflect.Field;
 import java.lang.reflect.Modifier;
+import java.util.ArrayDeque;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.Comparator;
+import java.util.Deque;
 import java.util.IdentityHashMap;
 import java.util.LinkedHashMap;
 import java.util.List;
@@ -22,7 +24,7 @@ public final class ProbeRuntime {
       new ConcurrentHashMap<>();
 
   private static final Object CAPTURE_LOCK = new Object();
-  private static final LinkedHashMap<String, CaptureEntry> CAPTURE_BY_METHOD_KEY =
+  private static final LinkedHashMap<String, Deque<CaptureEntry>> CAPTURE_BY_METHOD_KEY =
       new LinkedHashMap<>(16, 0.75f, true);
   private static final LinkedHashMap<String, CaptureEntry> CAPTURE_BY_ID = new LinkedHashMap<>();
   private static final AtomicLong CAPTURE_SEQ = new AtomicLong(0L);
@@ -40,6 +42,7 @@ public final class ProbeRuntime {
   private static volatile boolean CAPTURE_ENABLED = true;
   private static volatile int CAPTURE_MAX_KEYS = 1000;
   private static volatile int CAPTURE_MAX_ARGS = 32;
+  private static volatile int CAPTURE_METHOD_BUFFER_SIZE = 3;
   private static volatile int CAPTURE_PREVIEW_MAX_CHARS = 1024;
   private static volatile int CAPTURE_STORED_MAX_CHARS = 16384;
   private static volatile String CAPTURE_REDACTION_MODE = "basic";
@@ -71,6 +74,7 @@ public final class ProbeRuntime {
       boolean captureEnabled,
       int captureMaxKeys,
       int captureMaxArgs,
+      int captureMethodBufferSize,
       int capturePreviewMaxChars,
       int captureStoredMaxChars,
       String captureRedactionMode
@@ -78,6 +82,7 @@ public final class ProbeRuntime {
     CAPTURE_ENABLED = captureEnabled;
     CAPTURE_MAX_KEYS = clamp(captureMaxKeys, 10, 20_000, 1000);
     CAPTURE_MAX_ARGS = clamp(captureMaxArgs, 1, 512, 32);
+    CAPTURE_METHOD_BUFFER_SIZE = clamp(captureMethodBufferSize, 1, 32, 3);
     CAPTURE_PREVIEW_MAX_CHARS = clamp(capturePreviewMaxChars, 64, 65_536, 1024);
     CAPTURE_STORED_MAX_CHARS = clamp(captureStoredMaxChars, 256, 524_288, 16_384);
     if (CAPTURE_STORED_MAX_CHARS < CAPTURE_PREVIEW_MAX_CHARS) {
@@ -90,11 +95,6 @@ public final class ProbeRuntime {
     if (key == null || key.isEmpty()) return;
     COUNTS.computeIfAbsent(key, k -> new AtomicLong()).incrementAndGet();
     LAST_HIT_EPOCH_MS.computeIfAbsent(key, k -> new AtomicLong()).set(System.currentTimeMillis());
-  }
-
-  public static void hitByClassMethod(String dottedClassName, String methodName) {
-    if (dottedClassName == null || methodName == null) return;
-    hit(dottedClassName + "#" + methodName);
   }
 
   public static void captureByClassMethod(
@@ -127,11 +127,17 @@ public final class ProbeRuntime {
     );
 
     synchronized (CAPTURE_LOCK) {
-      CaptureEntry replaced = CAPTURE_BY_METHOD_KEY.put(methodKey, entry);
-      if (replaced != null) {
-        CAPTURE_BY_ID.remove(replaced.captureId);
+      Deque<CaptureEntry> methodCaptures = CAPTURE_BY_METHOD_KEY.get(methodKey);
+      if (methodCaptures == null) {
+        methodCaptures = new ArrayDeque<>();
+        CAPTURE_BY_METHOD_KEY.put(methodKey, methodCaptures);
       }
+      methodCaptures.addLast(entry);
       CAPTURE_BY_ID.put(captureId, entry);
+      while (methodCaptures.size() > CAPTURE_METHOD_BUFFER_SIZE) {
+        CaptureEntry removed = methodCaptures.removeFirst();
+        CAPTURE_BY_ID.remove(removed.captureId);
+      }
       evictCapturesIfNeeded();
     }
   }
@@ -206,7 +212,11 @@ public final class ProbeRuntime {
     String methodKey = toMethodKey(key);
     if (methodKey == null) return CapturePreviewView.unavailable(CAPTURE_REDACTION_MODE);
     synchronized (CAPTURE_LOCK) {
-      CaptureEntry entry = CAPTURE_BY_METHOD_KEY.get(methodKey);
+      Deque<CaptureEntry> captures = CAPTURE_BY_METHOD_KEY.get(methodKey);
+      if (captures == null || captures.isEmpty()) {
+        return CapturePreviewView.unavailable(CAPTURE_REDACTION_MODE);
+      }
+      CaptureEntry entry = captures.peekLast();
       if (entry == null) return CapturePreviewView.unavailable(CAPTURE_REDACTION_MODE);
       return entry.toPreview(CAPTURE_PREVIEW_MAX_CHARS);
     }
@@ -245,9 +255,11 @@ public final class ProbeRuntime {
     String methodKey = toMethodKey(key);
     if (methodKey != null) {
       synchronized (CAPTURE_LOCK) {
-        CaptureEntry removed = CAPTURE_BY_METHOD_KEY.remove(methodKey);
+        Deque<CaptureEntry> removed = CAPTURE_BY_METHOD_KEY.remove(methodKey);
         if (removed != null) {
-          CAPTURE_BY_ID.remove(removed.captureId);
+          for (CaptureEntry capture : removed) {
+            CAPTURE_BY_ID.remove(capture.captureId);
+          }
         }
       }
     }
@@ -511,10 +523,12 @@ public final class ProbeRuntime {
 
   private static void evictCapturesIfNeeded() {
     while (CAPTURE_BY_METHOD_KEY.size() > CAPTURE_MAX_KEYS) {
-      Map.Entry<String, CaptureEntry> eldest = CAPTURE_BY_METHOD_KEY.entrySet().iterator().next();
-      CaptureEntry removed = CAPTURE_BY_METHOD_KEY.remove(eldest.getKey());
+      Map.Entry<String, Deque<CaptureEntry>> eldest = CAPTURE_BY_METHOD_KEY.entrySet().iterator().next();
+      Deque<CaptureEntry> removed = CAPTURE_BY_METHOD_KEY.remove(eldest.getKey());
       if (removed != null) {
-        CAPTURE_BY_ID.remove(removed.captureId);
+        for (CaptureEntry capture : removed) {
+          CAPTURE_BY_ID.remove(capture.captureId);
+        }
       }
     }
   }


### PR DESCRIPTION
Implemented.

### What changed
- Added configurable capture history depth (`captureMethodBufferSize`) with startup precedence:
  - agent arg `captureMethodBufferSize`
  - JVM prop `mcp.probe.capture.method.buffer.size`
  - env `MCP_PROBE_CAPTURE_METHOD_BUFFER_SIZE`
  - default `3`, clamped `1..32`
  - Code: [AgentConfig.java](//mcp-jvm-debugger/java-agent/src/main/java/com/nimbly/mcpjvmdebugger/agent/AgentConfig.java), [ProbeAgent.java](/y/mcp-jvm-debugger/java-agent/src/main/java/com/nimbly/mcpjvmdebugger/agent/ProbeAgent.java)

- Removed method-enter hit counting path (`HitAdvice.onEnter`), kept method-exit capture.
  - Code: [HitAdvice.java](//mcp-jvm-debugger/java-agent/src/main/java/com/nimbly/mcpjvmdebugger/agent/HitAdvice.java)

- Reworked capture storage from single latest-per-method to bounded per-method deque/ring:
  - append newest on exit
  - evict oldest when size exceeds `captureMethodBufferSize`
  - remove evicted IDs from `captureId` map
  - `capturePreview` remains latest only
  - `/__probe/capture?captureId=...` unchanged
  - Code: [ProbeRuntime.java](//java-agent/src/main/java/com/nimbly/mcpjvmdebugger/agent/ProbeRuntime.java)

- Updated docs for `.env`/startup wiring and examples:
  - [java-agent/README.md](//mcp-jvm-debugger/java-agent/README.md)
  - [README.md](//mcp-jvm-debugger/README.md)

### Validation
- Ran: `mvn -f java-agent/pom.xml -DskipTests package`
- Result: `BUILD SUCCESS`

### Notes
- No MCP tool schema/data-field contract changes were made (`docs/data-fields/README.md` unchanged).