### PR TITLE
MCPJVM-230: Standardize SKILL activation metadata across clients by simplifying descriptions and removing non-portable invocation assumptions

### DIFF
--- a/skills/mcp-java-dev-tools-execution-profile-export/SKILL.md
+++ b/skills/mcp-java-dev-tools-execution-profile-export/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: mcp-java-dev-tools-execution-profile-export
-description: "Export execution profiles into deterministic self-contained artifacts using a single selected mode (ps1, sh, or postman)."
+description: "Export execution profiles to runnable artifacts (ps1, sh, postman). Use for export, share, replay, or handoff of regression execution flows."
 ---
 
 # MCP JVM Execution Profile Export

--- a/skills/mcp-java-dev-tools-issue-report/SKILL.md
+++ b/skills/mcp-java-dev-tools-issue-report/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: mcp-java-dev-tools-issue-report
-description: "Create sanitized, developer-ready issue reports from the current debugging session, workspace context, logs, stack traces, probe results, runtime evidence, and user input. Use when the user asks to document a bug, summarize a failure, prepare a reproducible issue report, or says things like 'I have this issue when calling this method'. Extract the minimum facts needed to reproduce the issue, preserve technical meaning, and remove secrets, bearer tokens, enterprise identifiers, company package names, and sensitive class names from the final output."
+description: "Create sanitized, reproducible bug/issue reports from session evidence. Use for issue tickets, failure summaries, repro steps, exceptions, or failing endpoints."
 ---
 
 # MCP Java Dev Tools Issue Report

--- a/skills/mcp-java-dev-tools-line-probe-run/SKILL.md
+++ b/skills/mcp-java-dev-tools-line-probe-run/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: mcp-java-dev-tools-line-probe-run
-description: "Run strict single-line JVM probe verification with mandatory MCP toolchain usage and fail-closed runtime route resolution."
+description: "Run strict single-line JVM probe verification. Use for line-hit checks, route validation, and fail-closed probe execution."
 ---
 
 # MCP JVM Line Probe Run

--- a/skills/mcp-java-dev-tools-probe-registry-manager/SKILL.md
+++ b/skills/mcp-java-dev-tools-probe-registry-manager/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: mcp-java-dev-tools-probe-registry-manager
-description: "Manage multi-probe registry entries on demand. Use when the user wants terminal-driven add/update/list flows for probe services, validate probe-config.json, reload registry, and produce MCP run configuration snippets."
+description: "Manage probe registry configuration (`probe-config.json`): add/update/list probes, validate config, reload registry, and generate MCP run snippets."
 ---
 
 # MCP Java Dev Tools Probe Registry Manager

--- a/skills/mcp-java-dev-tools-project-artifact-manager/SKILL.md
+++ b/skills/mcp-java-dev-tools-project-artifact-manager/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: mcp-java-dev-tools-project-artifact-manager
-description: "Manage persistent project artifacts under .mcpjvm/<project-name>/projects.json. Use when the user wants project context setup for runtime contexts, external systems, and health checks without duplicating probe-config."
+description: "Manage `.mcpjvm/<project>/projects.json` project context artifacts (read/validate/upsert/list) for runtime contexts, external systems, and health checks."
 ---
 
 # MCP Java Dev Tools Project Artifact Manager

--- a/skills/mcp-java-dev-tools-regression-plan-crafter/SKILL.md
+++ b/skills/mcp-java-dev-tools-regression-plan-crafter/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: mcp-java-dev-tools-regression-plan-crafter
-description: "Craft deterministic regression execution plans under .mcpjvm/<project_name>/plans/regression/<name>/ using metadata.json, contract.json, and plan.md with artifact lifecycle persisted via artifact_management."
+description: "Create or update deterministic regression plans (`metadata.json`, `contract.json`, `plan.md`) under `.mcpjvm/.../plans/regression`."
 ---
 
 # MCP JVM Regression Plan Crafter

--- a/skills/mcp-java-dev-tools-regression-result/SKILL.md
+++ b/skills/mcp-java-dev-tools-regression-result/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: mcp-java-dev-tools-regression-result
-description: "Render deterministic, artifact-derived regression results with extensible presentation modes (table-first)."
+description: "Render regression run results from artifacts into deterministic summaries and tables."
 ---
 
 # MCP JVM Regression Result

--- a/skills/mcp-java-dev-tools-regression-suite/SKILL.md
+++ b/skills/mcp-java-dev-tools-regression-suite/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: mcp-java-dev-tools-regression-suite
-description: "Run MCP-first HTTP regression suites across controller, service, or whole API scope with optional strict probe verification per endpoint."
+description: "Run MCP-first HTTP regression suites (endpoint, service, or API scope) with optional strict probe-hit verification."
 ---
 
 # MCP JVM Regression Suite


### PR DESCRIPTION
…implifying descriptions and removing non-portable invocation assumptions