### PR TITLE
MCPJVM-263: chore Stabilize failing TypeScript test suite regressionsa fter Artifact Tool and export-path changes (0.1.6v)

### DIFF
--- a/skills/mcp-java-dev-tools-probe-registry-manager/SKILL.md
+++ b/skills/mcp-java-dev-tools-probe-registry-manager/SKILL.md
@@ -5,11 +5,11 @@ description: "Manage probe registry configuration (`probe-config.json`): add/upd
 
 # MCP Java Dev Tools Probe Registry Manager
 
-Use this skill for operational management of `probe-config.json` and registry runtime refresh.
+Use this skill for operational management of `.mcpjvm/probe-config.json` and registry runtime refresh.
 
 ## Scope
 
-1. Add/update/remove probe entries in `probe-config.json`.
+1. Add/update/remove probe entries in `.mcpjvm/probe-config.json`.
 2. Validate deterministic registry shape (`defaultProfile`, `workspaces[]`, `profiles`, `probes`).
 3. Trigger `probe_registry_reload` after changes.
 4. Provide ready-to-paste MCP client configuration snippets.

--- a/test/tools/spring/artifact-management-contract.test.ts
+++ b/test/tools/spring/artifact-management-contract.test.ts
@@ -51,11 +51,12 @@ test("artifact_management handler accepts snake_case aliases inside typed input 
     registerArtifactManagementTool(server, { workspaceRootAbs: process.cwd() }),
   );
   const out = await handler({
-    artifactType: "run_result",
+    artifactType: "execution_export",
     action: "generate",
     input: {
       project_name: "test-project-performance",
       execution_profile: "test-performance-stress-suite",
+      mode: "sh",
     },
   });
   assert.notEqual(out.structuredContent.reasonCode, "artifact_request_invalid");

--- a/test/tools/spring/execution-profile-export-domain.test.ts
+++ b/test/tools/spring/execution-profile-export-domain.test.ts
@@ -46,6 +46,8 @@ function writeProject(root: string): void {
       },
     ],
   });
+  writePlanContract(root, "gateway-route-smoke-spec", projectName);
+  writePlanContract(root, "alternate-spec", projectName);
 }
 
 function writeProjectWithName(root: string, projectName: string, executionProfile: string, planName: string): void {
@@ -66,6 +68,9 @@ function writeProjectWithName(root: string, projectName: string, executionProfil
 }
 
 function writePlanContract(root: string, planName: string, projectName = "test-project"): void {
+  writeJson(path.join(root, ".mcpjvm", projectName, "plans", "regression", planName, "metadata.json"), {
+    execution: { intent: "regression" },
+  });
   writeJson(path.join(root, ".mcpjvm", projectName, "plans", "regression", planName, "contract.json"), {
     targets: [{ type: "class_method", selectors: { fqcn: "x.A", method: "m" } }],
     prerequisites: [],
@@ -85,6 +90,13 @@ function writePlanContract(root: string, planName: string, projectName = "test-p
       },
     ],
   });
+}
+
+function writePlanArtifact(root: string, planName: string, contract: Record<string, unknown>, projectName = "test-project"): void {
+  writeJson(path.join(root, ".mcpjvm", projectName, "plans", "regression", planName, "metadata.json"), {
+    execution: { intent: "regression" },
+  });
+  writeJson(path.join(root, ".mcpjvm", projectName, "plans", "regression", planName, "contract.json"), contract);
 }
 
 function readJson(filePath: string): any {
@@ -250,7 +262,10 @@ test("executionProfileExportDomain exports postman collection when scripts are J
     });
     const collection2 = readJson(String(out2.structuredContent.output?.collectionPathAbs));
     const environment2 = readJson(String(out2.structuredContent.output?.environmentPathAbs));
-    assert.deepEqual(collection2, collection);
+    assert.equal(collection2.info.schema, collection.info.schema);
+    assert.match(String(collection2.info.name ?? ""), /^execution-profile:regression-test-run:\d{8}-\d{6}-regression-test-run$/);
+    assert.match(String(collection.info.name ?? ""), /^execution-profile:regression-test-run:\d{8}-\d{6}-regression-test-run$/);
+    assert.deepEqual({ ...collection2, info: { ...collection2.info, name: "<normalized>" } }, { ...collection, info: { ...collection.info, name: "<normalized>" } });
     assert.deepEqual(environment2, environment);
   } finally {
     fs.rmSync(root, { recursive: true, force: true });
@@ -280,12 +295,12 @@ test("executionProfileExportDomain exports postman collection with plan folders 
         },
       ],
     });
-    writeJson(path.join(root, ".mcpjvm", projectName, "plans", "regression", "plan-a", "contract.json"), {
+    writePlanArtifact(root, "plan-a", {
       targets: [{ type: "class_method", selectors: { fqcn: "x.A", method: "m" } }],
       prerequisites: [],
       steps: [{ order: 1, id: "a1", targetRef: 0, protocol: "http", transport: { http: { method: "GET", url: "http://127.0.0.1:8080/a" } }, expect: [{ id: "e1", actualPath: "response.statusCode", operator: "numeric_gte", expected: 200 }] }],
     });
-    writeJson(path.join(root, ".mcpjvm", projectName, "plans", "regression", "plan-b", "contract.json"), {
+    writePlanArtifact(root, "plan-b", {
       targets: [{ type: "class_method", selectors: { fqcn: "x.B", method: "m" } }],
       prerequisites: [],
       steps: [{ order: 1, id: "b1", targetRef: 0, protocol: "http", transport: { http: { method: "GET", url: "http://127.0.0.1:8080/b" } }, expect: [{ id: "e2", actualPath: "response.statusCode", operator: "numeric_gte", expected: 200 }] }],
@@ -318,7 +333,7 @@ test("executionProfileExportDomain normalizes ${var} syntax and emits referenced
   try {
     writeProject(root);
     const projectName = "test-project";
-    writeJson(path.join(root, ".mcpjvm", projectName, "plans", "regression", "gateway-route-smoke-spec", "contract.json"), {
+    writePlanArtifact(root, "gateway-route-smoke-spec", {
       targets: [{ type: "class_method", selectors: { fqcn: "x.A", method: "m" } }],
       prerequisites: [],
       steps: [
@@ -365,7 +380,7 @@ test("executionProfileExportDomain fails closed for postman when url authority v
   try {
     writeProject(root);
     const projectName = "test-project";
-    writeJson(path.join(root, ".mcpjvm", projectName, "plans", "regression", "gateway-route-smoke-spec", "contract.json"), {
+    writePlanArtifact(root, "gateway-route-smoke-spec", {
       targets: [{ type: "class_method", selectors: { fqcn: "x.A", method: "m" } }],
       prerequisites: [],
       steps: [
@@ -400,7 +415,7 @@ test("executionProfileExportDomain applies prerequisite defaults and uses gatewa
   try {
     writeProject(root);
     const projectName = "test-project";
-    writeJson(path.join(root, ".mcpjvm", projectName, "plans", "regression", "gateway-route-smoke-spec", "contract.json"), {
+    writePlanArtifact(root, "gateway-route-smoke-spec", {
       targets: [{ type: "class_method", selectors: { fqcn: "x.A", method: "m" } }],
       prerequisites: [{ key: "gatewayBaseUrl", required: true, secret: false, provisioning: "user_input", default: "http://service-gateway" }],
       steps: [
@@ -452,7 +467,7 @@ test("executionProfileExportDomain resolves auth.bearer from workspace env when 
         },
       ],
     });
-    writeJson(path.join(root, ".mcpjvm", projectName, "plans", "regression", "gateway-route-smoke-spec", "contract.json"), {
+    writePlanArtifact(root, "gateway-route-smoke-spec", {
       targets: [{ type: "class_method", selectors: { fqcn: "x.A", method: "m" } }],
       prerequisites: [{ key: "auth.bearer", required: true, secret: true, provisioning: "user_input" }],
       steps: [{ order: 1, id: "s1", targetRef: 0, protocol: "http", transport: { http: { method: "GET", url: "http://127.0.0.1:8080/x", headers: { Authorization: "Bearer ${auth.bearer}" } } }, expect: [{ id: "e1", actualPath: "response.statusCode", operator: "numeric_gte", expected: 200 }] }],
@@ -493,7 +508,7 @@ test("executionProfileExportDomain resolves auth.bearer from sessionExport inclu
         },
       ],
     });
-    writeJson(path.join(root, ".mcpjvm", projectName, "plans", "regression", "gateway-route-smoke-spec", "contract.json"), {
+    writePlanArtifact(root, "gateway-route-smoke-spec", {
       targets: [{ type: "class_method", selectors: { fqcn: "x.A", method: "m" } }],
       prerequisites: [{ key: "auth.bearer", required: true, secret: true, provisioning: "user_input" }],
       steps: [{ order: 1, id: "s1", targetRef: 0, protocol: "http", transport: { http: { method: "GET", url: "http://127.0.0.1:8080/x", headers: { Authorization: "Bearer ${auth.bearer}" } } }, expect: [{ id: "e1", actualPath: "response.statusCode", operator: "numeric_gte", expected: 200 }] }],
@@ -530,7 +545,7 @@ test("executionProfileExportDomain resolves required auth.bearer via contextBind
         },
       ],
     });
-    writeJson(path.join(root, ".mcpjvm", projectName, "plans", "regression", "gateway-route-smoke-spec", "contract.json"), {
+    writePlanArtifact(root, "gateway-route-smoke-spec", {
       targets: [{ type: "class_method", selectors: { fqcn: "x.A", method: "m" } }],
       prerequisites: [{ key: "auth.bearer", required: true, secret: true, provisioning: "user_input" }],
       steps: [{ order: 1, id: "s1", targetRef: 0, protocol: "http", transport: { http: { method: "GET", url: "http://127.0.0.1:8080/x", headers: { Authorization: "Bearer ${auth.bearer}" } } }, expect: [{ id: "e1", actualPath: "response.statusCode", operator: "numeric_gte", expected: 200 }] }],
@@ -559,7 +574,7 @@ test("executionProfileExportDomain fails closed when required prerequisite remai
   try {
     writeProject(root);
     const projectName = "test-project";
-    writeJson(path.join(root, ".mcpjvm", projectName, "plans", "regression", "gateway-route-smoke-spec", "contract.json"), {
+    writePlanArtifact(root, "gateway-route-smoke-spec", {
       targets: [{ type: "class_method", selectors: { fqcn: "x.A", method: "m" } }],
       prerequisites: [{ key: "auth.bearer", required: true, secret: true, provisioning: "user_input" }],
       steps: [{ order: 1, id: "s1", targetRef: 0, protocol: "http", transport: { http: { method: "GET", url: "http://127.0.0.1:8080/x", headers: { Authorization: "Bearer ${auth.bearer}" } } }, expect: [{ id: "e1", actualPath: "response.statusCode", operator: "numeric_gte", expected: 200 }] }],
@@ -585,7 +600,7 @@ test("executionProfileExportDomain resolves required prerequisite from contextVa
   try {
     writeProject(root);
     const projectName = "test-project";
-    writeJson(path.join(root, ".mcpjvm", projectName, "plans", "regression", "gateway-route-smoke-spec", "contract.json"), {
+    writePlanArtifact(root, "gateway-route-smoke-spec", {
       targets: [{ type: "class_method", selectors: { fqcn: "x.A", method: "m" } }],
       prerequisites: [{ key: "auth.bearer", required: true, secret: true, provisioning: "user_input" }],
       steps: [{ order: 1, id: "s1", targetRef: 0, protocol: "http", transport: { http: { method: "GET", url: "http://127.0.0.1:8080/x", headers: { Authorization: "Bearer ${auth.bearer}" } } }, expect: [{ id: "e1", actualPath: "response.statusCode", operator: "numeric_gte", expected: 200 }] }],
@@ -613,7 +628,7 @@ test("executionProfileExportDomain supports derived required prerequisite via po
   try {
     writeProject(root);
     const projectName = "test-project";
-    writeJson(path.join(root, ".mcpjvm", projectName, "plans", "regression", "gateway-route-smoke-spec", "contract.json"), {
+    writePlanArtifact(root, "gateway-route-smoke-spec", {
       targets: [{ type: "class_method", selectors: { fqcn: "x.A", method: "m" } }],
       prerequisites: [{ key: "courseId", required: true, secret: false, provisioning: "user_input" }],
       steps: [
@@ -770,7 +785,7 @@ test("executionProfileExportDomain fails closed for postman when plan step trans
   try {
     writeProject(root);
     const projectName = "test-project";
-    writeJson(path.join(root, ".mcpjvm", projectName, "plans", "regression", "gateway-route-smoke-spec", "contract.json"), {
+    writePlanArtifact(root, "gateway-route-smoke-spec", {
       targets: [{ type: "class_method", selectors: { fqcn: "x.A", method: "m" } }],
       prerequisites: [],
       steps: [{ order: 1, id: "s1", targetRef: 0, protocol: "probe", transport: {} }],
@@ -800,7 +815,7 @@ test("executionProfileExportDomain fails closed for postman when url is unresolv
   try {
     writeProject(root);
     const projectName = "test-project";
-    writeJson(path.join(root, ".mcpjvm", projectName, "plans", "regression", "gateway-route-smoke-spec", "contract.json"), {
+    writePlanArtifact(root, "gateway-route-smoke-spec", {
       targets: [{ type: "class_method", selectors: { fqcn: "x.A", method: "m" } }],
       prerequisites: [],
       steps: [
@@ -839,7 +854,7 @@ test("executionProfileExportDomain fails closed for postman when url is not runn
   try {
     writeProject(root);
     const projectName = "test-project";
-    writeJson(path.join(root, ".mcpjvm", projectName, "plans", "regression", "gateway-route-smoke-spec", "contract.json"), {
+    writePlanArtifact(root, "gateway-route-smoke-spec", {
       targets: [{ type: "class_method", selectors: { fqcn: "x.A", method: "m" } }],
       prerequisites: [],
       steps: [
@@ -870,3 +885,4 @@ test("executionProfileExportDomain fails closed for postman when url is not runn
     fs.rmSync(root, { recursive: true, force: true });
   }
 });
+

--- a/test/tools/spring/regression-execution-profile-ps1-exporter.test.ts
+++ b/test/tools/spring/regression-execution-profile-ps1-exporter.test.ts
@@ -17,6 +17,21 @@ function writeJson(filePath: string, payload: Record<string, unknown>): void {
   fs.writeFileSync(filePath, `${JSON.stringify(payload, null, 2)}\n`, "utf8");
 }
 
+function writePlanArtifact(root: string, projectName: string, planName: string, contract?: Record<string, unknown>): void {
+  const planRoot = path.join(root, ".mcpjvm", projectName, "plans", "regression", planName);
+  writeJson(path.join(planRoot, "metadata.json"), {
+    execution: { intent: "regression" },
+  });
+  writeJson(
+    path.join(planRoot, "contract.json"),
+    contract ?? {
+      targets: [{ type: "class_method", selectors: { fqcn: "x.A", method: "m" } }],
+      prerequisites: [],
+      steps: [],
+    },
+  );
+}
+
 test("exportExecutionProfilePs1 writes deterministic script and readme from export manifest", async () => {
   const root = createTestTempDir("execution-profile-ps1-export");
   try {
@@ -58,6 +73,8 @@ test("exportExecutionProfilePs1 writes deterministic script and readme from expo
         },
       ],
     });
+    writePlanArtifact(root, projectName, "plan-a");
+    writePlanArtifact(root, projectName, "plan-b");
 
     const written = await writeExecutionProfileExport({
       workspaceRootAbs: root,
@@ -137,8 +154,7 @@ test("exportExecutionProfilePs1 emits native PowerShell HTTP requests without cu
       ],
     });
 
-    const planRoot = path.join(root, ".mcpjvm", projectName, "plans", "regression", "plan-a");
-    writeJson(path.join(planRoot, "contract.json"), {
+    writePlanArtifact(root, projectName, "plan-a", {
       targets: [{ type: "class_method", selectors: { fqcn: "x.A", method: "m" } }],
       prerequisites: [
         { key: "apiBaseUrl", required: true, secret: false, provisioning: "user_input", default: "http://localhost:8082" },
@@ -210,6 +226,7 @@ test("exportExecutionProfilePs1 includes sensitive warning when includeResolvedS
         },
       ],
     });
+    writePlanArtifact(root, projectName, "plan-a");
 
     await writeExecutionProfileExport({
       workspaceRootAbs: root,
@@ -274,6 +291,7 @@ test("exportExecutionProfilePs1 bundles shared profile scripts and export-local 
         },
       ],
     });
+    writePlanArtifact(root, projectName, "plan-a");
     const envFileAbs = path.join(root, ".mcpjvm", "test-project", ".env");
     fs.mkdirSync(path.dirname(envFileAbs), { recursive: true });
     fs.writeFileSync(envFileAbs, "AUTH_BEARER_TOKEN=secret-token\nKEYCLOAK_PASSWORD=password\n", "utf8");

--- a/test/tools/spring/regression-execution-profile-sh-exporter-no-manifest.test.ts
+++ b/test/tools/spring/regression-execution-profile-sh-exporter-no-manifest.test.ts
@@ -16,6 +16,18 @@ function writeJson(filePath: string, payload: Record<string, unknown>): void {
   fs.writeFileSync(filePath, `${JSON.stringify(payload, null, 2)}\n`, "utf8");
 }
 
+function writePlanArtifact(root: string, projectName: string, planName: string): void {
+  const planRoot = path.join(root, ".mcpjvm", projectName, "plans", "regression", planName);
+  writeJson(path.join(planRoot, "metadata.json"), {
+    execution: { intent: "regression" },
+  });
+  writeJson(path.join(planRoot, "contract.json"), {
+    targets: [{ type: "class_method", selectors: { fqcn: "x.A", method: "m" } }],
+    prerequisites: [],
+    steps: [],
+  });
+}
+
 test("exportExecutionProfileSh synthesizes export context from projects.json", async () => {
   const root = createTestTempDir("execution-profile-sh-no-manifest");
   try {
@@ -38,6 +50,8 @@ test("exportExecutionProfileSh synthesizes export context from projects.json", a
         },
       ],
     });
+    writePlanArtifact(root, projectName, "course-service-regression-spec");
+    writePlanArtifact(root, projectName, "review-service-regression-spec");
 
     const runDir = path.join(
       root,
@@ -86,6 +100,7 @@ test("exportExecutionProfileSh does not require a persisted export manifest", as
         },
       ],
     });
+    writePlanArtifact(root, projectName, "course-service-regression-spec");
 
     const runDir = path.join(
       root,

--- a/test/tools/spring/regression-execution-profile-sh-exporter.test.ts
+++ b/test/tools/spring/regression-execution-profile-sh-exporter.test.ts
@@ -17,6 +17,26 @@ function writeJson(filePath: string, payload: Record<string, unknown>): void {
   fs.writeFileSync(filePath, `${JSON.stringify(payload, null, 2)}\n`, "utf8");
 }
 
+function writePlanArtifact(
+  root: string,
+  projectName: string,
+  planName: string,
+  contract?: Record<string, unknown>,
+): void {
+  const planRoot = path.join(root, ".mcpjvm", projectName, "plans", "regression", planName);
+  writeJson(path.join(planRoot, "metadata.json"), {
+    execution: { intent: "regression" },
+  });
+  writeJson(
+    path.join(planRoot, "contract.json"),
+    contract ?? {
+      targets: [{ type: "class_method", selectors: { fqcn: "x.A", method: "m" } }],
+      prerequisites: [],
+      steps: [],
+    },
+  );
+}
+
 test("exportExecutionProfileSh writes deterministic script from export manifest", async () => {
   const root = createTestTempDir("execution-profile-sh-export");
   try {
@@ -79,6 +99,8 @@ test("exportExecutionProfileSh writes deterministic script from export manifest"
         },
       ],
     });
+    writePlanArtifact(root, projectName, "plan-a");
+    writePlanArtifact(root, projectName, "plan-b");
     const bootstrapScriptPath = path.join(root, ".mcpjvm", "test-project", "scripts", "bootstrap.sh");
     fs.mkdirSync(path.dirname(bootstrapScriptPath), { recursive: true });
     fs.writeFileSync(bootstrapScriptPath, "#!/usr/bin/env bash\necho BOOTSTRAPPED=true\n", "utf8");
@@ -172,6 +194,7 @@ test("exportExecutionProfileSh writes sh export as one-off artifact under export
         },
       ],
     });
+    writePlanArtifact(root, projectName, "plan-a");
 
     await writeExecutionProfileExport({
       workspaceRootAbs: root,
@@ -223,6 +246,7 @@ test("exportExecutionProfileSh emits docker teardown trap when runtime context o
         },
       ],
     });
+    writePlanArtifact(root, projectName, "plan-a");
 
     await writeExecutionProfileExport({
       workspaceRootAbs: root,
@@ -306,7 +330,7 @@ test("exportExecutionProfileSh does not infer API base URL from Docker compose w
     });
 
     const planRoot = path.join(root, ".mcpjvm", projectName, "plans", "regression", "course-service-regression-spec");
-    writeJson(path.join(planRoot, "contract.json"), {
+    writePlanArtifact(root, projectName, path.basename(planRoot), {
       targets: [{ type: "class_method", selectors: { fqcn: "x.Course", method: "post" } }],
       prerequisites: [],
       steps: [
@@ -400,7 +424,7 @@ test("exportExecutionProfileSh resolves terminal service base URL from probe-con
     });
 
     const planRoot = path.join(root, ".mcpjvm", projectName, "plans", "regression", "course-service-regression-spec");
-    writeJson(path.join(planRoot, "contract.json"), {
+    writePlanArtifact(root, projectName, path.basename(planRoot), {
       targets: [{ type: "class_method", selectors: { fqcn: "x.Course", method: "post" } }],
       prerequisites: [],
       steps: [
@@ -467,7 +491,7 @@ test("exportExecutionProfileSh uses execution profile plan providedContext apiBa
     });
 
     const planRoot = path.join(root, ".mcpjvm", projectName, "plans", "regression", "course-service-regression-spec");
-    writeJson(path.join(planRoot, "contract.json"), {
+    writePlanArtifact(root, projectName, path.basename(planRoot), {
       targets: [{ type: "class_method", selectors: { fqcn: "x.Course", method: "post" } }],
       prerequisites: [],
       steps: [
@@ -551,7 +575,7 @@ test("exportExecutionProfileSh aligns TARGET_BASE_URL default with resolved plan
       "regression",
       "course-composite-service-regression-spec",
     );
-    writeJson(path.join(planRoot, "contract.json"), {
+    writePlanArtifact(root, projectName, path.basename(planRoot), {
       targets: [{ type: "class_method", selectors: { fqcn: "x.Composite", method: "hello" } }],
       prerequisites: [
         { key: "targetBaseUrl", required: true, secret: false, provisioning: "user_input", default: "http://127.0.0.1:9000" },
@@ -644,7 +668,7 @@ test("exportExecutionProfileSh uses probe-config runtime.port even when Docker c
     });
 
     const planRoot = path.join(root, ".mcpjvm", projectName, "plans", "regression", "course-service-regression-spec");
-    writeJson(path.join(planRoot, "contract.json"), {
+    writePlanArtifact(root, projectName, path.basename(planRoot), {
       targets: [{ type: "class_method", selectors: { fqcn: "x.Course", method: "post" } }],
       prerequisites: [],
       steps: [
@@ -700,7 +724,7 @@ test("exportExecutionProfileSh emits endpoint-level HTTP commands for executed s
     });
 
     const planRoot = path.join(root, ".mcpjvm", projectName, "plans", "regression", "plan-a");
-    writeJson(path.join(planRoot, "contract.json"), {
+    writePlanArtifact(root, projectName, path.basename(planRoot), {
       targets: [{ type: "class_method", selectors: { fqcn: "x.A", method: "m" } }],
       prerequisites: [
         { key: "apiBaseUrl", required: true, secret: false, provisioning: "user_input", default: "http://localhost:8082" },
@@ -807,7 +831,7 @@ test("exportExecutionProfileSh does not inject AUTH_BEARER gate for non-auth HTT
     });
 
     const planRoot = path.join(root, ".mcpjvm", projectName, "plans", "regression", "producer-plan");
-    writeJson(path.join(planRoot, "contract.json"), {
+    writePlanArtifact(root, projectName, path.basename(planRoot), {
       targets: [{ type: "class_method", selectors: { fqcn: "x.Producer", method: "send" } }],
       prerequisites: [
         { key: "apiBaseUrl", required: true, secret: false, provisioning: "user_input", default: "http://127.0.0.1:8080" },
@@ -883,6 +907,7 @@ test("exportExecutionProfileSh bundles shared profile scripts and export-local p
         },
       ],
     });
+    writePlanArtifact(root, projectName, "plan-a");
     const envFileAbs = path.join(root, ".mcpjvm", "test-project", ".env");
     fs.mkdirSync(path.dirname(envFileAbs), { recursive: true });
     fs.writeFileSync(
@@ -966,6 +991,7 @@ test("exportExecutionProfileSh honors sessionExport includeResolvedSecrets for p
         },
       ],
     });
+    writePlanArtifact(root, projectName, "plan-a");
     const envFileAbs = path.join(root, ".mcpjvm", "test-project", ".env");
     fs.mkdirSync(path.dirname(envFileAbs), { recursive: true });
     fs.writeFileSync(envFileAbs, "KEYCLOAK_PASSWORD=password\nAUTH_BEARER_TOKEN=secret-token\n", "utf8");
@@ -995,3 +1021,4 @@ test("exportExecutionProfileSh honors sessionExport includeResolvedSecrets for p
     fs.rmSync(root, { recursive: true, force: true });
   }
 });
+


### PR DESCRIPTION
… after Artifact Tool and export-path changes (0.1.6v)