### PR TITLE
MCPJVM-308: execution_orchestration treats expected non-2xx HTTP steps as failures and ignores optional expectation semantics in run status

### DIFF
--- a/test/integrations/others/mcp/execution_orchestration.it.ts
+++ b/test/integrations/others/mcp/execution_orchestration.it.ts
@@ -489,10 +489,10 @@ test("mcp IT: execution_orchestration resolves project contextBindings from env-
   }
 });
 
-test("mcp IT: execution_orchestration passes intentional non-2xx sad-path assertions and persists clean step artifacts", async () => {
+test("mcp IT: execution_orchestration passes transport-failure contract-matched assertions and persists clean step artifacts", async () => {
   const tmpRoot = await fs.mkdtemp(path.join(os.tmpdir(), "mcp-execution-orchestration-sad-path-it-"));
   const workspaceRootAbs = path.join(tmpRoot, "workspace");
-  const projectName = "test-project-sad-path";
+  const projectName = "petclinic-regression";
   const projectRootAbs = workspaceRootAbs;
   const probeConfigAbs = path.join(workspaceRootAbs, ".mcpjvm", "probe-config.json");
   const planName = "missing-resource-regression";
@@ -613,6 +613,149 @@ test("mcp IT: execution_orchestration passes intentional non-2xx sad-path assert
     assert.equal(executionResult.steps?.[0]?.statusCode, 404);
     assert.equal(executionResult.steps?.[0]?.reasonCode, undefined);
     assert.equal(executionResult.steps?.[0]?.reasonMeta, undefined);
+  } finally {
+    appServer.close();
+    await mcp?.close();
+    if (fssync.existsSync(tmpRoot)) {
+      await fs.rm(tmpRoot, { recursive: true, force: true });
+    }
+  }
+});
+
+test("mcp IT: execution_orchestration keeps optional-only transport-failure step failures out of overall run status", async () => {
+  const tmpRoot = await fs.mkdtemp(path.join(os.tmpdir(), "mcp-execution-orchestration-sad-path-optional-it-"));
+  const workspaceRootAbs = path.join(tmpRoot, "workspace");
+  const projectName = "petclinic-regression";
+  const projectRootAbs = workspaceRootAbs;
+  const probeConfigAbs = path.join(workspaceRootAbs, ".mcpjvm", "probe-config.json");
+  const planName = "missing-resource-optional-regression";
+  const planRootAbs = path.join(
+    workspaceRootAbs,
+    ".mcpjvm",
+    projectName,
+    "plans",
+    "regression",
+    planName,
+  );
+  const runRootAbs = path.join(planRootAbs, "runs");
+  const appServer = http.createServer((req, res) => {
+    if (req.url === "/api/missing-resource") {
+      res.statusCode = 500;
+      res.setHeader("content-type", "application/json");
+      res.end(JSON.stringify({ reason: "unexpected route" }));
+      return;
+    }
+    res.statusCode = 404;
+    res.setHeader("content-type", "application/json");
+    res.end(JSON.stringify({ reason: "missing route" }));
+  });
+  const appPort = await listen(appServer);
+
+  await writeJson(probeConfigAbs, {
+    defaultProfile: "dev",
+    profiles: {
+      dev: {
+        probes: { "gateway-service": { baseUrl: "http://127.0.0.1:9196", include: ["com.example.**"], exclude: [] } },
+      },
+    },
+    workspaces: [{ root: workspaceRootAbs, profile: "dev" }],
+  });
+
+  await writeJson(path.join(workspaceRootAbs, ".mcpjvm", projectName, "projects.json"), {
+    workspaces: [
+      {
+        projectRoot: projectRootAbs,
+        executionProfiles: [
+          {
+            executionProfile: "sad-path-optional-run",
+            executionPolicy: "stop_on_fail",
+            plans: [{ order: 1, planName, onFail: "inherit" }],
+          },
+        ],
+      },
+    ],
+  });
+  await writeJson(path.join(planRootAbs, "metadata.json"), {
+    execution: { intent: "regression" },
+  });
+  await writeJson(path.join(planRootAbs, "contract.json"), {
+    targets: [{ type: "class_method", selectors: { fqcn: "x.A", method: "m" } }],
+    prerequisites: [
+      {
+        key: "apiBaseUrl",
+        required: true,
+        secret: false,
+        provisioning: "user_input",
+        default: `http://127.0.0.1:${appPort}`,
+      },
+    ],
+    steps: [
+      {
+        order: 1,
+        id: "missing_resource_optional",
+        targetRef: 0,
+        protocol: "http",
+        transport: {
+          http: {
+            method: "GET",
+            pathTemplate: "/api/missing-resource",
+          },
+        },
+        expect: [
+          {
+            id: "status_not_found_optional",
+            actualPath: "response.statusCode",
+            operator: "field_equals",
+            expected: 404,
+            required: false,
+          },
+          {
+            id: "body_reason_missing_optional",
+            actualPath: "response.body",
+            operator: "contains",
+            expected: "missing",
+            required: false,
+          },
+        ],
+      },
+    ],
+  });
+
+  let mcp: Awaited<ReturnType<typeof startMcpClient>> | undefined;
+  try {
+    mcp = await startMcpClient({
+      workspaceRootAbs,
+      probeBaseUrl: "http://127.0.0.1:9196",
+      extraEnv: { MCP_PROBE_CONFIG_FILE: probeConfigAbs },
+    });
+
+    const out = await callTool(mcp, "execution_orchestration", {
+      action: "execute",
+      input: {
+        projectName,
+        executionProfile: "sad-path-optional-run",
+      },
+    });
+
+    assert.equal(out.structuredContent?.resultType, "execution_orchestration");
+    assert.equal(out.structuredContent?.status, "pass");
+    const planRuns = Array.isArray(out.structuredContent?.planRuns)
+      ? (out.structuredContent?.planRuns as Array<Record<string, unknown>>)
+      : [];
+    assert.equal(planRuns.length, 1);
+    assert.equal(planRuns[0]?.status, "executed");
+    assert.equal(planRuns[0]?.runStatus, "pass");
+    assert.equal(fssync.existsSync(runRootAbs), true);
+
+    const runIds = await fs.readdir(runRootAbs);
+    assert.equal(runIds.length, 1);
+    const executionResult = JSON.parse(
+      await fs.readFile(path.join(runRootAbs, runIds[0]!, "execution.result.json"), "utf8"),
+    ) as { steps?: Array<Record<string, unknown>>; status?: string };
+    assert.equal(executionResult.status, "pass");
+    assert.equal(Array.isArray(executionResult.steps), true);
+    assert.equal(executionResult.steps?.[0]?.status, "fail_assertion");
+    assert.equal(executionResult.steps?.[0]?.statusCode, 500);
   } finally {
     appServer.close();
     await mcp?.close();

--- a/test/tools/spring/regression-expectation-evaluator.test.ts
+++ b/test/tools/spring/regression-expectation-evaluator.test.ts
@@ -19,7 +19,7 @@ test("evaluateStepExpectations returns pass when all required expectations pass"
         },
       },
     },
-    httpFailure: false,
+    transportFailure: false,
     dependencyBlocked: false,
     expectations: [
       {
@@ -54,7 +54,7 @@ test("evaluateStepExpectations returns fail_assertion when required predicate fa
       status: "pass",
       transport: { status_code: 500 },
     },
-    httpFailure: false,
+    transportFailure: false,
     dependencyBlocked: false,
     expectations: [
       {
@@ -75,7 +75,7 @@ test("evaluateStepExpectations returns blocked_runtime on invalid expectation ma
     stepResult: {
       status: "pass",
     },
-    httpFailure: false,
+    transportFailure: false,
     dependencyBlocked: false,
     expectations: [
       {
@@ -90,10 +90,10 @@ test("evaluateStepExpectations returns blocked_runtime on invalid expectation ma
   assert.equal(evaluated.assertions[0].reasonCode, "actual_path_missing");
 });
 
-test("evaluateStepExpectations prefers dependency/http failures over assertion pass", () => {
+test("evaluateStepExpectations prefers dependency or transport failures over assertion pass", () => {
   const dependencyBlocked = evaluateStepExpectations({
     stepResult: { status: "pass" },
-    httpFailure: false,
+    transportFailure: false,
     dependencyBlocked: true,
     expectations: [
       {
@@ -108,7 +108,7 @@ test("evaluateStepExpectations prefers dependency/http failures over assertion p
 
   const httpFailed = evaluateStepExpectations({
     stepResult: { status: "fail", response: { statusCode: 500 } },
-    httpFailure: true,
+    transportFailure: true,
     dependencyBlocked: false,
     expectations: [
       {
@@ -120,16 +120,16 @@ test("evaluateStepExpectations prefers dependency/http failures over assertion p
       },
     ],
   });
-  assert.equal(httpFailed.status, "fail_http");
+  assert.equal(httpFailed.status, "pass");
 });
 
-test("evaluateStepExpectations treats expected non-2xx response as pass when required assertions succeed", () => {
+test("evaluateStepExpectations treats transport failures as pass when authored assertions succeed", () => {
   const evaluated = evaluateStepExpectations({
     stepResult: {
       status: "fail",
       response: { statusCode: 404, body: "{\"error\":\"missing\"}" },
     },
-    httpFailure: true,
+    transportFailure: true,
     dependencyBlocked: false,
     expectations: [
       {
@@ -151,6 +151,36 @@ test("evaluateStepExpectations treats expected non-2xx response as pass when req
   assert.equal(evaluated.assertions.every((entry: { status: string }) => entry.status === "pass"), true);
 });
 
+test("evaluateStepExpectations fails step when any authored assertion fails on transport failure", () => {
+  const evaluated = evaluateStepExpectations({
+    stepResult: {
+      status: "fail",
+      response: { statusCode: 404, body: "{\"error\":\"unexpected\"}" },
+    },
+    transportFailure: true,
+    dependencyBlocked: false,
+    expectations: [
+      {
+        id: "http-not-found",
+        actualPath: "response.statusCode",
+        operator: "field_equals",
+        expected: 404,
+      },
+      {
+        id: "body-has-missing",
+        actualPath: "response.body",
+        operator: "contains",
+        expected: "missing",
+        required: false,
+      },
+    ],
+  });
+
+  assert.equal(evaluated.status, "fail_assertion");
+  assert.equal(evaluated.assertions[0].status, "pass");
+  assert.equal(evaluated.assertions[1].status, "fail");
+});
+
 test("evaluateStepExpectations supports array index notation in actualPath", () => {
   const evaluated = evaluateStepExpectations({
     stepResult: {
@@ -163,7 +193,7 @@ test("evaluateStepExpectations supports array index notation in actualPath", () 
         },
       },
     },
-    httpFailure: false,
+    transportFailure: false,
     dependencyBlocked: false,
     expectations: [
       {
@@ -198,6 +228,13 @@ test("deriveRunStatusFromStepOutcomes maps continue-on-fail policy deterministic
   assert.equal(
     deriveRunStatusFromStepOutcomes({
       hardRuntimeBlocker: false,
+      stepOutcomes: [{ status: "pass" }, { status: "fail_http", required: false }],
+    }),
+    "pass",
+  );
+  assert.equal(
+    deriveRunStatusFromStepOutcomes({
+      hardRuntimeBlocker: false,
       stepOutcomes: [{ status: "pass" }, { status: "blocked_dependency" }],
     }),
     "fail",
@@ -210,4 +247,3 @@ test("deriveRunStatusFromStepOutcomes maps continue-on-fail policy deterministic
     "pass",
   );
 });
-

--- a/test/tools/spring/regression-plan-executor.test.ts
+++ b/test/tools/spring/regression-plan-executor.test.ts
@@ -416,7 +416,7 @@ test("executeRegressionPlanWorkflow infers apiBaseUrl from probe-config runtime.
   }
 });
 
-test("executeRegressionPlanWorkflow passes intentional non-2xx sad-path step when required assertions match", async () => {
+test("executeRegressionPlanWorkflow passes transport-failure step when authored assertions match", async () => {
   const root = createTestTempDir("plan-executor-sad-path-http");
   try {
     const projectName = "petclinic-regression";
@@ -470,6 +470,181 @@ test("executeRegressionPlanWorkflow passes intentional non-2xx sad-path step whe
       assert.equal(out.executionResult.steps[0].statusCode, 404);
       assert.equal(out.executionResult.steps[0].reasonCode, undefined);
       assert.equal(out.executionResult.steps[0].reasonMeta, undefined);
+    }
+  } finally {
+    fs.rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test("executeRegressionPlanWorkflow treats optional-only transport-failure step as non-required in run status", async () => {
+  const root = createTestTempDir("plan-executor-sad-path-optional");
+  try {
+    const projectName = "petclinic-regression";
+    const planName = "missing-entity-optional-check";
+    const planRoot = path.join(root, ".mcpjvm", projectName, "plans", "regression", planName);
+    writeJson(path.join(root, ".mcpjvm", projectName, "projects.json"), {
+      workspaces: [{ projectRoot: root, runtimeContexts: [{ name: "terminal-cli", mode: "terminal", autoStart: false }] }],
+    });
+    writeJson(path.join(planRoot, "metadata.json"), {
+      specVersion: "1.0.0",
+      execution: { intent: "regression", probeVerification: false, pinStrictProbeKey: false, discoveryPolicy: "allow_discoverable_prerequisites" },
+    });
+    writeJson(path.join(planRoot, "contract.json"), {
+      targets: [{ type: "class_method", selectors: { fqcn: "org.example.VisitsController", method: "readMissing", sourceRoot: "src/main/java" } }],
+      prerequisites: [{ key: "apiBaseUrl", required: true, secret: false, provisioning: "user_input", default: "http://localhost:8082" }],
+      steps: [
+        {
+          order: 1,
+          id: "read_missing_visit_optional",
+          targetRef: 0,
+          protocol: "http",
+          transport: { http: { method: "GET", pathTemplate: "/visits/404" } },
+          expect: [
+            { id: "http-not-found", actualPath: "response.statusCode", operator: "field_equals", expected: 404, required: false },
+            { id: "body-reason", actualPath: "response.body", operator: "contains", expected: "missing", required: false },
+          ],
+        },
+      ],
+    });
+
+    const out = await executeRegressionPlanWorkflow({
+      workspaceRootAbs: root,
+      planName,
+      mcpInvoke: async ({ toolName }: { toolName: string; input: Record<string, unknown> }) => {
+        assert.equal(toolName, "transport_execute");
+        return {
+          structuredContent: {
+            status: "fail_http",
+            statusCode: 404,
+            durationMs: 9,
+            bodyPreview: "{\"reason\":\"missing\"}",
+          },
+        };
+      },
+    });
+
+    assert.equal(out.status, "executed");
+    if (out.status === "executed") {
+      assert.equal(out.runStatus, "pass");
+      assert.equal(out.executionResult.steps[0].status, "pass");
+      assert.equal(out.executionResult.steps[0].assertions.every((entry: { status: string }) => entry.status === "pass"), true);
+    }
+  } finally {
+    fs.rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test("executeRegressionPlanWorkflow does not fail overall run for optional-only transport-failure mismatch", async () => {
+  const root = createTestTempDir("plan-executor-sad-path-optional-mismatch");
+  try {
+    const projectName = "petclinic-regression";
+    const planName = "missing-entity-optional-mismatch";
+    const planRoot = path.join(root, ".mcpjvm", projectName, "plans", "regression", planName);
+    writeJson(path.join(root, ".mcpjvm", projectName, "projects.json"), {
+      workspaces: [{ projectRoot: root, runtimeContexts: [{ name: "terminal-cli", mode: "terminal", autoStart: false }] }],
+    });
+    writeJson(path.join(planRoot, "metadata.json"), {
+      specVersion: "1.0.0",
+      execution: { intent: "regression", probeVerification: false, pinStrictProbeKey: false, discoveryPolicy: "allow_discoverable_prerequisites" },
+    });
+    writeJson(path.join(planRoot, "contract.json"), {
+      targets: [{ type: "class_method", selectors: { fqcn: "org.example.VisitsController", method: "readMissing", sourceRoot: "src/main/java" } }],
+      prerequisites: [{ key: "apiBaseUrl", required: true, secret: false, provisioning: "user_input", default: "http://localhost:8082" }],
+      steps: [
+        {
+          order: 1,
+          id: "read_missing_visit_optional_mismatch",
+          targetRef: 0,
+          protocol: "http",
+          transport: { http: { method: "GET", pathTemplate: "/visits/404" } },
+          expect: [
+            { id: "http-not-found", actualPath: "response.statusCode", operator: "field_equals", expected: 404, required: false },
+            { id: "body-reason", actualPath: "response.body", operator: "contains", expected: "missing", required: false },
+          ],
+        },
+      ],
+    });
+
+    const out = await executeRegressionPlanWorkflow({
+      workspaceRootAbs: root,
+      planName,
+      mcpInvoke: async ({ toolName }: { toolName: string; input: Record<string, unknown> }) => {
+        assert.equal(toolName, "transport_execute");
+        return {
+          structuredContent: {
+            status: "fail_http",
+            statusCode: 500,
+            durationMs: 9,
+            bodyPreview: "{\"reason\":\"unexpected\"}",
+          },
+        };
+      },
+    });
+
+    assert.equal(out.status, "executed");
+    if (out.status === "executed") {
+      assert.equal(out.runStatus, "pass");
+      assert.equal(out.executionResult.steps[0].status, "fail_assertion");
+      assert.equal(out.executionResult.steps[0].assertions.some((entry: { status: string }) => entry.status === "fail"), true);
+    }
+  } finally {
+    fs.rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test("executeRegressionPlanWorkflow fails overall run when a required step has any authored expectation mismatch", async () => {
+  const root = createTestTempDir("plan-executor-transport-failure-mixed-mismatch");
+  try {
+    const projectName = "petclinic-regression";
+    const planName = "missing-entity-mixed-mismatch";
+    const planRoot = path.join(root, ".mcpjvm", projectName, "plans", "regression", planName);
+    writeJson(path.join(root, ".mcpjvm", projectName, "projects.json"), {
+      workspaces: [{ projectRoot: root, runtimeContexts: [{ name: "terminal-cli", mode: "terminal", autoStart: false }] }],
+    });
+    writeJson(path.join(planRoot, "metadata.json"), {
+      specVersion: "1.0.0",
+      execution: { intent: "regression", probeVerification: false, pinStrictProbeKey: false, discoveryPolicy: "allow_discoverable_prerequisites" },
+    });
+    writeJson(path.join(planRoot, "contract.json"), {
+      targets: [{ type: "class_method", selectors: { fqcn: "org.example.VisitsController", method: "readMissing", sourceRoot: "src/main/java" } }],
+      prerequisites: [{ key: "apiBaseUrl", required: true, secret: false, provisioning: "user_input", default: "http://localhost:8082" }],
+      steps: [
+        {
+          order: 1,
+          id: "read_missing_visit_mixed_mismatch",
+          targetRef: 0,
+          protocol: "http",
+          transport: { http: { method: "GET", pathTemplate: "/visits/404" } },
+          expect: [
+            { id: "http-not-found", actualPath: "response.statusCode", operator: "field_equals", expected: 404 },
+            { id: "body-reason", actualPath: "response.body", operator: "contains", expected: "missing", required: false },
+          ],
+        },
+      ],
+    });
+
+    const out = await executeRegressionPlanWorkflow({
+      workspaceRootAbs: root,
+      planName,
+      mcpInvoke: async ({ toolName }: { toolName: string; input: Record<string, unknown> }) => {
+        assert.equal(toolName, "transport_execute");
+        return {
+          structuredContent: {
+            status: "fail_http",
+            statusCode: 404,
+            durationMs: 9,
+            bodyPreview: "{\"reason\":\"unexpected\"}",
+          },
+        };
+      },
+    });
+
+    assert.equal(out.status, "executed");
+    if (out.status === "executed") {
+      assert.equal(out.runStatus, "fail");
+      assert.equal(out.executionResult.steps[0].status, "fail_assertion");
+      assert.equal(out.executionResult.steps[0].assertions[0].status, "pass");
+      assert.equal(out.executionResult.steps[0].assertions[1].status, "fail");
     }
   } finally {
     fs.rmSync(root, { recursive: true, force: true });

--- a/tools/spec/regression-execution-plan-spec/src/regression_expectation_evaluator.util.ts
+++ b/tools/spec/regression-execution-plan-spec/src/regression_expectation_evaluator.util.ts
@@ -160,7 +160,7 @@ function operatorNeedsExpected(operator: PlanStepExpectationOperator): boolean {
 export function evaluateStepExpectations(args: {
   stepResult: Record<string, unknown>;
   expectations: PlanStepExpectation[];
-  httpFailure: boolean;
+  transportFailure: boolean;
   dependencyBlocked: boolean;
 }): EvaluateStepExpectationsResult {
   const assertions: StepAssertionEvaluation[] = [];
@@ -221,20 +221,19 @@ export function evaluateStepExpectations(args: {
   if (args.dependencyBlocked) {
     return { assertions, status: "blocked_dependency" };
   }
-  const requiredAssertions = assertions.filter((entry) => entry.required);
-  if (requiredAssertions.some((entry) => entry.status === "blocked_invalid")) {
+  if (assertions.some((entry) => entry.status === "blocked_invalid")) {
     return { assertions, status: "blocked_runtime" };
   }
-  if (requiredAssertions.some((entry) => entry.status === "fail")) {
+  if (assertions.some((entry) => entry.status === "fail")) {
     return { assertions, status: "fail_assertion" };
   }
-  if (args.httpFailure) {
-    // If the plan supplied at least one required expectation and all required
-    // expectations passed, treat the non-2xx response as an intentional sad-path
-    // assertion rather than a transport-level failure.
+  if (args.transportFailure) {
+    // Step status follows the authored expectations. The required flag is
+    // applied later when deriving whether a non-pass step should fail the
+    // overall run.
     return {
       assertions,
-      status: requiredAssertions.length > 0 ? "pass" : "fail_http",
+      status: assertions.length > 0 ? "pass" : "fail_http",
     };
   }
   return { assertions, status: "pass" };

--- a/tools/spec/regression-execution-plan-spec/src/regression_plan_executor.util.ts
+++ b/tools/spec/regression-execution-plan-spec/src/regression_plan_executor.util.ts
@@ -435,6 +435,13 @@ function buildPlanCorrelationEvidence(args: {
   };
 }
 
+function isStepRequired(step: PlanStep | undefined): boolean {
+  if (!step || !Array.isArray(step.expect) || step.expect.length === 0) {
+    return true;
+  }
+  return step.expect.some((expectation) => expectation.required !== false);
+}
+
 export async function executeRegressionPlanWorkflow(
   args: ExecuteRegressionPlanWorkflowArgs,
 ): Promise<ExecuteRegressionPlanWorkflowResult> {
@@ -624,7 +631,7 @@ export async function executeRegressionPlanWorkflow(
     const evalResult = evaluateStepExpectations({
       stepResult: stepEnvelope,
       expectations: step.expect,
-      httpFailure: transport.status === "fail_http",
+      transportFailure: transport.status === "fail_http",
       dependencyBlocked: transport.status === "blocked_invalid" || transport.status === "blocked_runtime",
     });
     const transportReasonMeta = resolveTransportReasonMeta(transport);
@@ -658,7 +665,10 @@ export async function executeRegressionPlanWorkflow(
 
   const ended = new Date();
   const runStatus = deriveRunStatusFromStepOutcomes({
-    stepOutcomes: stepRows.map((row) => ({ status: row.status as any })),
+    stepOutcomes: stepRows.map((row) => ({
+      status: row.status as any,
+      required: isStepRequired(contract.steps.find((step) => step.order === row.order && step.id === row.id)),
+    })),
     hardRuntimeBlocker,
   });
   const executionResult: RegressionRunExecutionResult = {


### PR DESCRIPTION
…s as failures and ignores optional expectation semantics in run status